### PR TITLE
Fix pyproject for uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,6 @@ uvicorn = "0.34.0"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.uv]
+package = false

--- a/uv.lock
+++ b/uv.lock
@@ -228,7 +228,7 @@ wheels = [
 [[package]]
 name = "tough-client"
 version = "0.1.0"
-source = { editable = "." }
+source = { virtual = "." }
 dependencies = [
     { name = "click" },
     { name = "fastapi" },


### PR DESCRIPTION
Was failing because it thought it had to use the build system data.